### PR TITLE
Support the V4 signature version

### DIFF
--- a/s3rap/s3rap.py
+++ b/s3rap/s3rap.py
@@ -2,9 +2,10 @@ import logging
 import os
 import gzip
 import boto3
+from botocore.client import Config
 
-s3resource = boto3.resource('s3')
-s3client = boto3.client('s3')
+s3resource = boto3.resource('s3', config=Config(signature_version='s3v4'))
+s3client = boto3.client('s3', config=Config(signature_version='s3v4'))
 logger = logging.getLogger(__name__)
 
 def get_object(bucket, key):


### PR DESCRIPTION
The issue is related to this: 
http://stackoverflow.com/questions/26533245/the-authorization-mechanism-you-have-provided-is-not-supported-please-use-aws4

In a nutshell, newer AWS regions don't support the default signature version, so you need to specify exactly what you need.
